### PR TITLE
오류 수정

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,20 +3,26 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 

--- a/lib/controller/calendar_viewController.dart
+++ b/lib/controller/calendar_viewController.dart
@@ -1,13 +1,28 @@
 import 'package:mvc_pattern/mvc_pattern.dart';
+import 'package:todaybills/model/repository/bills_repository.dart';
 
 class CalendarViewcontroller extends ControllerMVC {
-  DateTime selectedDay = DateTime.now();
-  DateTime focuseDay = DateTime.now();
+  final BillsRepository repository;
+  late DateTime selectedDay;
+  late DateTime focusedDay;
 
-  void onDaySeleted(DateTime selected, DateTime focused) {
+  CalendarViewcontroller({required this.repository}) {
+    // 초기값은 나중에 _initializeCalendar() 에서 덮어씁니다.
+    selectedDay = DateTime.now();
+    focusedDay = DateTime.now();
+  }
+
+  void initializeLatestAvailableDate(DateTime dt) {
     setState(() {
-      selectedDay = selected;
-      focuseDay = focused;
+      selectedDay = dt;
+      focusedDay = dt;
+    });
+  }
+
+  void onDaySelected(DateTime sel, DateTime foc) {
+    setState(() {
+      selectedDay = sel;
+      focusedDay = foc;
     });
   }
 }

--- a/lib/controller/list_viewController.dart
+++ b/lib/controller/list_viewController.dart
@@ -12,9 +12,10 @@ class ListViewcontroller extends ControllerMVC {
   final String id = "";
   final String age = "";
 
-  final BillsRepository _billsRepository = BillsRepository();
+  final BillsRepository _billsRepository;
 
-  ListViewcontroller() {
+  ListViewcontroller({required BillsRepository repository})
+      : _billsRepository = repository {
     fetchLaws();
     loadFavorites();
   }

--- a/lib/controller/search_viewController.dart
+++ b/lib/controller/search_viewController.dart
@@ -3,9 +3,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:todaybills/controller/list_viewController.dart';
 import 'package:todaybills/model/data/bill.dart';
 import 'package:todaybills/model/data/law.dart';
+import 'package:todaybills/model/repository/bills_repository.dart';
 import 'package:todaybills/model/service/search_service.dart';
 
-class SearchViewController extends ListViewcontroller {
+final class SearchViewController extends ListViewcontroller {
   List<String> filteredItems = [];
   final List<String> keywords = ["부동산", "안전", "근로", "산업", "환경", "교육"];
   List<Law> searchList = []; // 검색 결과
@@ -13,10 +14,12 @@ class SearchViewController extends ListViewcontroller {
 
   final TextEditingController searchController = TextEditingController();
   final SearchService searchService = SearchService();
+  final BillsRepository repository;
 
-  SearchViewController() {
+  SearchViewController(this.repository) : super(repository: BillsRepository()) {
     searchController.addListener(onSearchChanged);
   }
+
   @override
   void initState() {
     super.initState();

--- a/lib/controller/search_viewController.dart
+++ b/lib/controller/search_viewController.dart
@@ -6,19 +6,19 @@ import 'package:todaybills/model/data/law.dart';
 import 'package:todaybills/model/repository/bills_repository.dart';
 import 'package:todaybills/model/service/search_service.dart';
 
-final class SearchViewController extends ListViewcontroller {
+class SearchViewController extends ListViewcontroller {
   List<String> filteredItems = [];
   final List<String> keywords = ["부동산", "안전", "근로", "산업", "환경", "교육"];
   List<Law> searchList = []; // 검색 결과
   List<String> recentSearches = []; // 최근 검색어 리스트
 
   final TextEditingController searchController = TextEditingController();
-  final SearchService searchService = SearchService();
-  final BillsRepository repository;
+  final SearchService searchService;
 
-  SearchViewController(this.repository) : super(repository: BillsRepository()) {
-    searchController.addListener(onSearchChanged);
-  }
+  SearchViewController({
+    required super.repository,
+    required this.searchService,
+  });
 
   @override
   void initState() {
@@ -36,6 +36,7 @@ final class SearchViewController extends ListViewcontroller {
   void onTapKeyword(String keyword) {
     searchController.text = keyword;
     _saveRecentSearch(keyword);
+    onSearchChanged();
   }
 
   Law convertBillToLaw(Bill bill) {
@@ -56,8 +57,14 @@ final class SearchViewController extends ListViewcontroller {
     }
 
     final results = await searchService.searchBillsByKeywords(query);
+    _saveRecentSearch(query);
+    final uniqueMap = <String, Law>{};
+    for (final bill in results) {
+      final law = convertBillToLaw(bill);
+      uniqueMap[law.ID] = law;
+    }
     setState(() {
-      searchList = results.map((bill) => convertBillToLaw(bill)).toList();
+      searchList = uniqueMap.values.toList();
     });
   }
 

--- a/lib/controller/star_viewController.dart
+++ b/lib/controller/star_viewController.dart
@@ -1,7 +1,9 @@
 import 'package:todaybills/controller/list_viewController.dart';
 import 'package:todaybills/model/data/law.dart';
 
-class StarViewcontroller extends ListViewcontroller {
+final class StarViewcontroller extends ListViewcontroller {
+  StarViewcontroller({required super.repository});
+
   @override
   void initState() {
     super.initState();

--- a/lib/model/repository/bills_repository.dart
+++ b/lib/model/repository/bills_repository.dart
@@ -11,7 +11,7 @@ final class BillsRepositoryError implements Exception {
   String toString() => message;
 }
 
-class BillsRepository {
+final class BillsRepository {
   final BillService billsService = BillService();
   // 날짜별 법안들을 저장하는 Map (키: "yyyy-MM-dd", 값: List<Law>)
   final Map<String, List<Law>> billsByDate = {};

--- a/lib/model/service/html_scrapper.dart
+++ b/lib/model/service/html_scrapper.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as parser;
 
-class HtmlScrapper {
+final class HtmlScrapper {
   Future<String?> fetchPageContent(String urlString) async {
     try {
       final response = await http.get(Uri.parse(urlString));

--- a/lib/view/calendar/calendar_view.dart
+++ b/lib/view/calendar/calendar_view.dart
@@ -8,12 +8,10 @@ import 'package:todaybills/model/repository/bills_repository.dart';
 class CalendarView extends StatefulWidget {
   final DateTime selectedDate;
   final ValueChanged<DateTime> onDateSelected;
-  final BillsRepository repository;
 
   const CalendarView({
     required this.selectedDate,
     required this.onDateSelected,
-    required this.repository,
     super.key,
   });
 
@@ -21,7 +19,11 @@ class CalendarView extends StatefulWidget {
   StateMVC<CalendarView> createState() => _CalendarViewState();
 }
 
-class _CalendarViewState extends StateMVC<CalendarView> {
+class _CalendarViewState extends StateMVC<CalendarView>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
   late CalendarViewcontroller _controller;
 
   _CalendarViewState()
@@ -52,6 +54,7 @@ class _CalendarViewState extends StateMVC<CalendarView> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return TableCalendar(
       headerStyle: HeaderStyle(
         formatButtonVisible: false,

--- a/lib/view/calendar/calendar_view.dart
+++ b/lib/view/calendar/calendar_view.dart
@@ -3,54 +3,71 @@ import 'package:flutter/material.dart';
 import 'package:mvc_pattern/mvc_pattern.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:todaybills/controller/calendar_viewController.dart';
+import 'package:todaybills/model/repository/bills_repository.dart';
 
 class CalendarView extends StatefulWidget {
   final DateTime selectedDate;
   final ValueChanged<DateTime> onDateSelected;
+  final BillsRepository repository;
 
   const CalendarView({
     required this.selectedDate,
     required this.onDateSelected,
+    required this.repository,
     super.key,
   });
 
   @override
-  _CalendarViewState createState() => _CalendarViewState();
+  StateMVC<CalendarView> createState() => _CalendarViewState();
 }
 
 class _CalendarViewState extends StateMVC<CalendarView> {
   late CalendarViewcontroller _controller;
-  late DateTime _focusedDay;
 
-  _CalendarViewState() : super(CalendarViewcontroller()) {
+  _CalendarViewState()
+      : super(CalendarViewcontroller(repository: BillsRepository())) {
     _controller = controller as CalendarViewcontroller;
   }
 
   @override
   void initState() {
     super.initState();
-    _focusedDay = widget.selectedDate;
+    _initializeCalendar();
+  }
+
+  Future<void> _initializeCalendar() async {
+    await _controller.repository.fetchBills(
+      date: DateTime.now(),
+      isUserSelectingDate: false,
+    );
+
+    final latestKey = _controller.repository.getLatestAvailableDate();
+    if (latestKey != null) {
+      final dt = DateTime.parse(latestKey);
+      _controller.initializeLatestAvailableDate(dt);
+      widget.onDateSelected(dt);
+      setState(() {});
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: TableCalendar(
-        focusedDay: _controller.focuseDay,
-        firstDay: DateTime.utc(2020, 1, 1),
-        lastDay: DateTime.utc(2030, 12, 31),
-        locale: 'ko-KR',
-        daysOfWeekHeight: 30,
-        selectedDayPredicate: (day) => isSameDay(_controller.selectedDay, day),
-        onDaySelected: (selectedDay, focusedDay) {
-          setState(() {
-            _focusedDay = focusedDay;
-          });
-          _controller.onDaySeleted(selectedDay, focusedDay);
-          widget.onDateSelected(selectedDay);
-        },
-        calendarFormat: CalendarFormat.month,
+    return TableCalendar(
+      headerStyle: HeaderStyle(
+        formatButtonVisible: false,
       ),
+      focusedDay: _controller.focusedDay,
+      firstDay: DateTime.utc(2020, 1, 1),
+      lastDay: DateTime.utc(2030, 12, 31),
+      locale: 'ko-KR',
+      daysOfWeekHeight: 30,
+      selectedDayPredicate: (day) => isSameDay(_controller.selectedDay, day),
+      onDaySelected: (selectedDay, focusedDay) {
+        setState(() {});
+        _controller.onDaySelected(selectedDay, focusedDay);
+        widget.onDateSelected(selectedDay);
+      },
+      calendarFormat: CalendarFormat.month,
     );
   }
 }

--- a/lib/view/calendar/law_list_view.dart
+++ b/lib/view/calendar/law_list_view.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:mvc_pattern/mvc_pattern.dart';
 import 'package:todaybills/controller/list_viewController.dart';
+import 'package:todaybills/model/repository/bills_repository.dart';
 import 'package:todaybills/view/reusable_law_list/reusable_law_list_view.dart';
 
-class LawListView extends StatefulWidget {
+final class LawListView extends StatefulWidget {
   final DateTime selectedDate;
 
   const LawListView({
@@ -15,10 +16,13 @@ class LawListView extends StatefulWidget {
   _ListViewState createState() => _ListViewState();
 }
 
-class _ListViewState extends StateMVC<LawListView> {
+final class _ListViewState extends StateMVC<LawListView> {
   late ListViewcontroller _controller;
 
-  _ListViewState() : super(ListViewcontroller()) {
+  _ListViewState()
+      : super(ListViewcontroller(
+          repository: BillsRepository(),
+        )) {
     _controller = controller as ListViewcontroller;
   }
 

--- a/lib/view/calendar/law_list_view.dart
+++ b/lib/view/calendar/law_list_view.dart
@@ -1,25 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:mvc_pattern/mvc_pattern.dart';
 import 'package:todaybills/controller/list_viewController.dart';
+import 'package:todaybills/model/data/law.dart';
 import 'package:todaybills/model/repository/bills_repository.dart';
 import 'package:todaybills/view/reusable_law_list/reusable_law_list_view.dart';
 
-final class LawListView extends StatefulWidget {
-  final DateTime selectedDate;
+class LawListView extends StatefulWidget {
+  final DateTime? selectedDate;
+  final List<Law>? overrideLaws;
 
   const LawListView({
     super.key,
-    required this.selectedDate,
+    this.selectedDate,
+    this.overrideLaws,
   });
 
   @override
-  _ListViewState createState() => _ListViewState();
+  ListViewState createState() => ListViewState();
 }
 
-final class _ListViewState extends StateMVC<LawListView> {
+class ListViewState extends StateMVC<LawListView> {
   late ListViewcontroller _controller;
 
-  _ListViewState()
+  ListViewState()
       : super(ListViewcontroller(
           repository: BillsRepository(),
         )) {
@@ -29,16 +32,34 @@ final class _ListViewState extends StateMVC<LawListView> {
   @override
   void initState() {
     super.initState();
-    _controller.fetchLaws();
+    _applyModeAndFetch();
+    _controller.loadFavorites();
   }
 
   @override
   void didUpdateWidget(covariant LawListView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.selectedDate != widget.selectedDate) {
-      _controller.fetchLaws(date: widget.selectedDate);
-      _controller.updateDate(widget.selectedDate);
+    if (oldWidget.overrideLaws != widget.overrideLaws) {
+      _applyModeAndFetch();
+      return;
     }
+    if (widget.overrideLaws == null &&
+        oldWidget.selectedDate != widget.selectedDate) {
+      _controller.fetchLaws(date: widget.selectedDate);
+    }
+  }
+
+  void _applyModeAndFetch() {
+    if (widget.overrideLaws != null) {
+      _controller.laws = widget.overrideLaws!;
+    } else {
+      _controller.fetchLaws(date: widget.selectedDate);
+    }
+  }
+
+  void refreshFavorites() {
+    _controller.loadFavorites();
+    setState(() {});
   }
 
   @override

--- a/lib/view/detail/expandable_label_view.dart
+++ b/lib/view/detail/expandable_label_view.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class ExpandableLabelView extends StatefulWidget {
+final class ExpandableLabelView extends StatefulWidget {
   final String text;
 
   const ExpandableLabelView({
@@ -12,7 +12,7 @@ class ExpandableLabelView extends StatefulWidget {
   State<ExpandableLabelView> createState() => _ExpandableLabelViewState();
 }
 
-class _ExpandableLabelViewState extends State<ExpandableLabelView>
+final class _ExpandableLabelViewState extends State<ExpandableLabelView>
     with TickerProviderStateMixin {
   bool isExpanded = false;
 

--- a/lib/view/detail/timeline_item_view.dart
+++ b/lib/view/detail/timeline_item_view.dart
@@ -1,8 +1,7 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:todaybills/model/data/timeline_step.dart';
 
-class TimelineItemView extends StatelessWidget {
+final class TimelineItemView extends StatelessWidget {
   final TimelineStep step;
 
   const TimelineItemView({

--- a/lib/view/detail/timeline_view.dart
+++ b/lib/view/detail/timeline_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:todaybills/model/data/timeline_step.dart';
 import 'package:todaybills/view/detail/timeline_item_view.dart';
 
-class TimelineView extends StatelessWidget {
+final class TimelineView extends StatelessWidget {
   final List<TimelineStep> steps;
 
   const TimelineView({

--- a/lib/view/home/home_view.dart
+++ b/lib/view/home/home_view.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:todaybills/controller/calendar_viewController.dart';
 import 'package:todaybills/model/repository/bills_repository.dart';
 import 'package:todaybills/view/calendar/calendar_view.dart';
 import 'package:todaybills/view/calendar/law_list_view.dart';
 
 final class homeView extends StatefulWidget {
-  const homeView({super.key});
+  final GlobalKey<ListViewState> lawListKey;
+  const homeView({
+    required this.lawListKey,
+  });
 
   @override
   State<StatefulWidget> createState() => _homeViewState();
@@ -30,7 +34,6 @@ final class _homeViewState extends State<homeView> {
             child: CalendarView(
               selectedDate: _selectedDate,
               onDateSelected: _onDateSelected,
-              repository: BillsRepository(),
             ),
           ),
           const Divider(
@@ -39,6 +42,7 @@ final class _homeViewState extends State<homeView> {
           ),
           Expanded(
             child: LawListView(
+              key: widget.lawListKey,
               selectedDate: _selectedDate,
             ),
           ),

--- a/lib/view/home/home_view.dart
+++ b/lib/view/home/home_view.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:todaybills/model/repository/bills_repository.dart';
 import 'package:todaybills/view/calendar/calendar_view.dart';
 import 'package:todaybills/view/calendar/law_list_view.dart';
 
-class homeView extends StatefulWidget {
+final class homeView extends StatefulWidget {
   const homeView({super.key});
 
   @override
   State<StatefulWidget> createState() => _homeViewState();
 }
 
-class _homeViewState extends State<homeView> {
+final class _homeViewState extends State<homeView> {
   DateTime _selectedDate = DateTime.now();
 
   void _onDateSelected(DateTime newDate) {
@@ -29,6 +30,7 @@ class _homeViewState extends State<homeView> {
             child: CalendarView(
               selectedDate: _selectedDate,
               onDateSelected: _onDateSelected,
+              repository: BillsRepository(),
             ),
           ),
           const Divider(

--- a/lib/view/home/maintab_view.dart
+++ b/lib/view/home/maintab_view.dart
@@ -1,51 +1,67 @@
 import 'package:flutter/material.dart';
+import 'package:todaybills/view/calendar/law_list_view.dart';
 import 'package:todaybills/view/home/home_view.dart';
 import 'package:todaybills/view/search/search_view.dart';
 import 'package:todaybills/view/star/star_view.dart';
 
-final class MaintabView extends StatefulWidget {
+class MaintabView extends StatefulWidget {
   const MaintabView({super.key});
 
   @override
-  State<StatefulWidget> createState() => _MaintabViewState();
+  State<MaintabView> createState() => _MaintabViewState();
 }
 
-final class _MaintabViewState extends State<MaintabView> {
+class _MaintabViewState extends State<MaintabView> {
   int _selectedIndex = 0;
+  late final List<Widget> _persistentPages;
 
-  static final List<Widget> _pages = <Widget>[
-    homeView(),
-    SearchView(),
-    StarView()
-  ];
+  // LawListView 갱신용 키
+  final GlobalKey<ListViewState> _lawListKey = GlobalKey<ListViewState>();
+  final GlobalKey<ListViewState> _searchlawListKey = GlobalKey<ListViewState>();
 
-  void _onItemTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
+  @override
+  void initState() {
+    super.initState();
+    _persistentPages = [
+      homeView(lawListKey: _lawListKey),
+      SearchView(lawListKey: _searchlawListKey),
+    ];
+  }
+
+  void _onItemTapped(int idx) {
+    setState(() => _selectedIndex = idx);
+    if (idx == 0) {
+      _lawListKey.currentState?.refreshFavorites();
+    } else if (idx == 1) {
+      _searchlawListKey.currentState?.refreshFavorites();
+    }
   }
 
   @override
   Widget build(BuildContext context) {
+    final pages = <Widget>[
+      _persistentPages[0],
+      _persistentPages[1],
+      if (_selectedIndex == 2) StarView() else const SizedBox.shrink(),
+    ];
+
     return Scaffold(
-      body: _pages[_selectedIndex],
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: pages,
+      ),
       bottomNavigationBar: BottomNavigationBar(
-          currentIndex: _selectedIndex,
-          onTap: _onItemTapped,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.home),
-              label: '',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.search),
-              label: '',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.star),
-              label: '',
-            )
-          ]),
+        currentIndex: _selectedIndex,
+        onTap: _onItemTapped,
+        type: BottomNavigationBarType.fixed,
+        showSelectedLabels: false,
+        showUnselectedLabels: false,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: ''),
+          BottomNavigationBarItem(icon: Icon(Icons.search), label: ''),
+          BottomNavigationBarItem(icon: Icon(Icons.star), label: ''),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/home/maintab_view.dart
+++ b/lib/view/home/maintab_view.dart
@@ -3,14 +3,14 @@ import 'package:todaybills/view/home/home_view.dart';
 import 'package:todaybills/view/search/search_view.dart';
 import 'package:todaybills/view/star/star_view.dart';
 
-class MaintabView extends StatefulWidget {
+final class MaintabView extends StatefulWidget {
   const MaintabView({super.key});
 
   @override
   State<StatefulWidget> createState() => _MaintabViewState();
 }
 
-class _MaintabViewState extends State<MaintabView> {
+final class _MaintabViewState extends State<MaintabView> {
   int _selectedIndex = 0;
 
   static final List<Widget> _pages = <Widget>[

--- a/lib/view/reusable_law_list/reusable_law_list_view.dart
+++ b/lib/view/reusable_law_list/reusable_law_list_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:todaybills/model/data/law.dart';
 
-class ReusableLawListView extends StatelessWidget {
+final class ReusableLawListView extends StatelessWidget {
   final List<Law> laws;
   final Set<Law> favoriteIems;
   final void Function(Law) onToggleFavorite;

--- a/lib/view/search/search_view.dart
+++ b/lib/view/search/search_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mvc_pattern/mvc_pattern.dart';
 import 'package:todaybills/controller/search_viewController.dart';
-import 'package:todaybills/model/data/law.dart';
 import 'package:todaybills/view/reusable_law_list/reusable_law_list_view.dart';
 
 class SearchView extends StatefulWidget {
@@ -13,7 +12,7 @@ class SearchView extends StatefulWidget {
 class _SearchViewState extends StateMVC<SearchView> {
   late SearchViewController _controller;
 
-  _SearchViewState() : super(SearchViewController()) {
+  _SearchViewState() : super() {
     _controller = controller as SearchViewController;
   }
 

--- a/lib/view/search/search_view.dart
+++ b/lib/view/search/search_view.dart
@@ -1,19 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:mvc_pattern/mvc_pattern.dart';
 import 'package:todaybills/controller/search_viewController.dart';
-import 'package:todaybills/view/reusable_law_list/reusable_law_list_view.dart';
+import 'package:todaybills/model/repository/bills_repository.dart';
+import 'package:todaybills/model/service/search_service.dart';
+import 'package:todaybills/view/calendar/law_list_view.dart';
 
 class SearchView extends StatefulWidget {
-  const SearchView({super.key});
+  final GlobalKey<ListViewState> lawListKey;
+
+  const SearchView({
+    super.key,
+    required this.lawListKey,
+  });
+
   @override
   State<StatefulWidget> createState() => _SearchViewState();
 }
 
 class _SearchViewState extends StateMVC<SearchView> {
-  late SearchViewController _controller;
+  late final SearchViewController _controller;
 
-  _SearchViewState() : super() {
+  _SearchViewState()
+      : super(SearchViewController(
+          repository: BillsRepository(),
+          searchService: SearchService(),
+        )) {
     _controller = controller as SearchViewController;
+  }
+
+  void refreshFavorites() {
+    _controller.loadFavorites();
+    setState(() {});
   }
 
   @override
@@ -32,6 +49,9 @@ class _SearchViewState extends StateMVC<SearchView> {
                 hintText: "법안을 검색해 보세요",
                 border: OutlineInputBorder(),
               ),
+              onSubmitted: (value) {
+                _controller.onSearchChanged();
+              },
             ),
           ),
           Padding(
@@ -69,21 +89,9 @@ class _SearchViewState extends StateMVC<SearchView> {
               valueListenable: _controller.searchController,
               builder: (context, value, child) {
                 final query = value.text.trim();
-                if (query.isNotEmpty) {
-                  final results = _controller.searchList;
-                  if (results.isEmpty) {
-                    return const Center(
-                      child: Text("검색 결과가 없습니다."),
-                    );
-                  } else {
-                    return ReusableLawListView(
-                      laws: results,
-                      favoriteIems: _controller.favoriteItems,
-                      onToggleFavorite: _controller.toggleFavorite,
-                      onSelected: _controller.onSeleted,
-                    );
-                  }
-                } else {
+                final results = _controller.searchList;
+
+                if (query.isEmpty) {
                   return Column(
                     children: [
                       Padding(
@@ -128,6 +136,16 @@ class _SearchViewState extends StateMVC<SearchView> {
                         ),
                       ),
                     ],
+                  );
+                }
+                if (results.isEmpty) {
+                  return const Center(
+                    child: Text("검색 결과가 없습니다."),
+                  );
+                } else {
+                  return LawListView(
+                    key: widget.lawListKey,
+                    overrideLaws: results,
                   );
                 }
               },

--- a/lib/view/star/star_view.dart
+++ b/lib/view/star/star_view.dart
@@ -3,17 +3,17 @@ import 'package:mvc_pattern/mvc_pattern.dart';
 import 'package:todaybills/controller/star_viewController.dart';
 import 'package:todaybills/view/reusable_law_list/reusable_law_list_view.dart';
 
-class StarView extends StatefulWidget {
+final class StarView extends StatefulWidget {
   const StarView({super.key});
 
   @override
   State<StatefulWidget> createState() => _StarView();
 }
 
-class _StarView extends StateMVC<StarView> {
+final class _StarView extends StateMVC<StarView> {
   late StarViewcontroller _controller;
 
-  _StarView() : super(StarViewcontroller()) {
+  _StarView() : super() {
     _controller = controller as StarViewcontroller;
   }
 

--- a/lib/view/star/star_view.dart
+++ b/lib/view/star/star_view.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:mvc_pattern/mvc_pattern.dart';
 import 'package:todaybills/controller/star_viewController.dart';
+import 'package:todaybills/model/repository/bills_repository.dart';
 import 'package:todaybills/view/reusable_law_list/reusable_law_list_view.dart';
 
 final class StarView extends StatefulWidget {
-  const StarView({super.key});
+  const StarView({
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() => _StarView();
@@ -13,7 +16,7 @@ final class StarView extends StatefulWidget {
 final class _StarView extends StateMVC<StarView> {
   late StarViewcontroller _controller;
 
-  _StarView() : super() {
+  _StarView() : super(StarViewcontroller(repository: BillsRepository())) {
     _controller = controller as StarViewcontroller;
   }
 


### PR DESCRIPTION
### PR 개요
오류 수정
---
### 주요 변경 사항

1. **탭 위젯 초기화 전략 변경**  
   - `homeView` 와 `SearchView` 는 `initState` 시 한 번만 생성해서 상태를 그대로 유지  
   - `StarView` 는 매번 탭 선택 시 새로 생성하도록 변경하여 항상 최신 즐겨찾기 반영  

2. **GlobalKey를 통한 `LawListView` 상태 제어**  
   - `homeView` 와 `SearchView` 에 `GlobalKey<ListViewState>` 를 전달  
   - 탭 전환 시 (`onTap`) 해당 키로 `refreshFavorites()` 를 호출해  
     - SharedPreferences 에 저장된 즐겨찾기를 다시 로드  
     - `setState()` 로 UI 갱신  

3. **`LawListView` 및 `ListViewState` 확장**  
   - `refreshFavorites()` 메서드 추가  
   - 내부 컨트롤러의 `loadFavorites()` 호출 후 `setState()`  
   - `didUpdateWidget` 를 활용해 날짜 변경 시 법안 목록도 정상 업데이트  

4. **`SearchView` 에도 동일한 즐겨찾기 동기화 로직 적용**  
   - 검색 결과 리스트에도 별도의 `GlobalKey` 를 부여  
   - 홈 탭과 동일하게 탭 선택 시 `refreshFavorites()` 호출  

5. **기타 버그 수정**  
   - `IndexedStack` 과 비-`const` 위젯 조합으로 불필요한 재생성 방지  
   - `CalendarView` 초기화 로직에서 최초 한 번만 API 호출하도록 `_isInitialized` 플래그 적용 